### PR TITLE
Cursor auto-hide GD4

### DIFF
--- a/autoloads/UserSettings.gd
+++ b/autoloads/UserSettings.gd
@@ -64,7 +64,7 @@ func _ready():
 
 	add_child(mouse_hide_timer)
 	#TODO GD4
-	mouse_hide_timer.wait_time = 0.5
+	mouse_hide_timer.wait_time = 1.0
 	mouse_hide_timer.one_shot = true
 	mouse_hide_timer.connect("timeout", Callable(Input, "set_mouse_mode").bind(Input.MOUSE_MODE_HIDDEN))
 	# Godot simulates joy connections on startup, this makes sure we skip them
@@ -378,21 +378,18 @@ enum PROMPT_MODE {
 var current_mode = PROMPT_MODE.KEYBOARD
 func _input(event):
 	process_mode = Node.PROCESS_MODE_ALWAYS
-	if event is InputEventKey:
-		mouse_hide_timer.start()
-		if current_mode != PROMPT_MODE.KEYBOARD:
-			current_mode = PROMPT_MODE.KEYBOARD
-	if event is InputEventJoypadButton:
-		mouse_hide_timer.start()
-		if current_mode != PROMPT_MODE.JOYPAD:
-			current_mode = PROMPT_MODE.JOYPAD
-	if event is InputEventMouseMotion and event.relative.is_equal_approx(Vector2.ZERO) or event is InputEventMouseButton:
-		if current_mode == PROMPT_MODE.KEYBOARD:
+	if event is InputEventJoypadButton or event is InputEventKey:
+		if event is InputEventMouseMotion or event is InputEventMouseButton:
 			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-			mouse_hide_timer.stop()
-		if current_mode == PROMPT_MODE.JOYPAD:
-			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		elif mouse_hide_timer.time_left == 0:
 			mouse_hide_timer.start()
+		if event is InputEventKey and (current_mode != PROMPT_MODE.KEYBOARD):
+			current_mode = PROMPT_MODE.KEYBOARD
+		elif event is InputEventJoypadButton and (current_mode != PROMPT_MODE.JOYPAD):
+			current_mode = PROMPT_MODE.JOYPAD
+	elif (event is InputEventMouseMotion and event.relative.is_equal_approx(Vector2.ZERO)) or event is InputEventMouseButton:
+		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		mouse_hide_timer.stop()
 func load_user_settings():
 	var usp = HBGame.platform_settings.user_dir_redirect(USER_SETTINGS_PATH)
 	var file := FileAccess.open(usp, FileAccess.READ)

--- a/tools/editor/Editor.gd
+++ b/tools/editor/Editor.gd
@@ -154,9 +154,11 @@ func update_shortcuts():
 
 func _ready():
 	UserSettings.enable_menu_fps_limits = false
+	UserSettings.mouse_hide_timer.stop()
 	add_child(game_playback)
 	game_playback.connect("playback_speed_changed", Callable(self, "_on_playback_speed_changed"))
 	game_playback.connect("time_changed", Callable(self, "_on_game_playback_time_changed"))
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	Input.set_use_accumulated_input(true)
 	get_window().content_scale_mode = Window.CONTENT_SCALE_MODE_DISABLED
 	#get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_EXPAND, Vector2(1280, 720))


### PR DESCRIPTION
Enabling cursor auto-hide and stuff for the current Godot4 branch. 
Like with 0.17 (The game's current stable branch), it auto-hides the cursor when using a controller.
Unlike 0.17, it also auto-hides when using keyboard, so that keyboard gameplay and menu navigation can be done without the cursor always being annoying over in the corner or something.

Auto-hide timer stopped and cursor made visible when opening the Editor so you don't end up having a ghost cursor on the chart select screen.