### PR TITLE
Add X DSC support to the chart import tool

### DIFF
--- a/autoloads/song_loader/song_loaders/DSCConverter.gd
+++ b/autoloads/song_loader/song_loaders/DSCConverter.gd
@@ -291,16 +291,16 @@ static func convert_dsc_opcodes_to_chart(r: Array, opcode_map: DSCOpcodeMap, off
 					
 					if is_double(opcode.params[0]):
 						note_d = HBDoubleNote.new()
-						note_d.time += (curr_time / 100.0)
+						note_d.time += (curr_time / 100.0) + offset
 					
 					elif is_sustain(opcode.params[0]):
 						note_d = HBSustainNote.new()
-						note_d.time += (curr_time / 100.0)
+						note_d.time += (curr_time / 100.0) + offset
 						(note_d as HBSustainNote).end_time = (curr_time / 100.0) + opcode.params[9] + (opcode.params[1] / 100.0) + offset
 					
 					elif is_rush(opcode.params[0]):
 						note_d = HBRushNote.new()
-						note_d.time += (curr_time / 100.0)
+						note_d.time += (curr_time / 100.0) + offset
 						(note_d as HBRushNote).end_time = (curr_time / 100.0) + opcode.params[9] + (opcode.params[1] / 100.0) + offset
 					
 					# F note coords are in 50:15 aspect ratio

--- a/autoloads/song_loader/song_loaders/DSCConverter.gd
+++ b/autoloads/song_loader/song_loaders/DSCConverter.gd
@@ -103,8 +103,13 @@ enum FButtons {
 	STAR = 0xC,
 	STAR_DOUBLE = 0xE,
 	CHANCE_STAR = 0xF,
+	STAR_RUSH = 0x11,
 	LINKED_STAR = 0x16,
-	LINKED_STAR_END = 0x17
+	LINKED_STAR_END = 0x17,
+	TRIANGLE_RUSH = 0x19,
+	CIRCLE_RUSH = 0x1A,
+	CROSS_RUSH = 0x1B,
+	SQUARE_RUSH = 0x1C
 }
 
 const F2PHButtonMap = {
@@ -123,8 +128,13 @@ const F2PHButtonMap = {
 	FButtons.STAR: HBBaseNote.NOTE_TYPE.HEART,
 	FButtons.STAR_DOUBLE: HBBaseNote.NOTE_TYPE.HEART,
 	FButtons.CHANCE_STAR: HBBaseNote.NOTE_TYPE.HEART,
+	FButtons.STAR_RUSH: HBBaseNote.NOTE_TYPE.HEART,
 	FButtons.LINKED_STAR: HBBaseNote.NOTE_TYPE.HEART,
 	FButtons.LINKED_STAR_END: HBBaseNote.NOTE_TYPE.HEART,
+	FButtons.TRIANGLE_RUSH: HBBaseNote.NOTE_TYPE.UP,
+	FButtons.CIRCLE_RUSH: HBBaseNote.NOTE_TYPE.RIGHT,
+	FButtons.CROSS_RUSH: HBBaseNote.NOTE_TYPE.DOWN,
+	FButtons.SQUARE_RUSH: HBBaseNote.NOTE_TYPE.LEFT,
 }
 
 const AFT2PHButtonMap = {
@@ -156,6 +166,9 @@ static func is_double(button: int):
 
 static func is_sustain(button: int):
 	return button >= FButtons.TRIANGLE_HOLD and button <= FButtons.SQUARE_HOLD
+
+static func is_rush(button: int):
+	return (button >= FButtons.TRIANGLE_RUSH and button <= FButtons.SQUARE_RUSH) or button == FButtons.STAR_RUSH
 
 static func convert_dsc_buffer_to_chart(buffer: StreamPeerBuffer, opcode_map: DSCOpcodeMap) -> HBChart:
 	var r = load_dsc_file_from_buff(buffer, opcode_map)
@@ -284,6 +297,11 @@ static func convert_dsc_opcodes_to_chart(r: Array, opcode_map: DSCOpcodeMap, off
 						note_d = HBSustainNote.new()
 						note_d.time += (curr_time / 100.0)
 						(note_d as HBSustainNote).end_time = (curr_time / 100.0) + opcode.params[9] + (opcode.params[1] / 100.0) + offset
+					
+					elif is_rush(opcode.params[0]):
+						note_d = HBRushNote.new()
+						note_d.time += (curr_time / 100.0)
+						(note_d as HBRushNote).end_time = (curr_time / 100.0) + opcode.params[9] + (opcode.params[1] / 100.0) + offset
 					
 					# F note coords are in 50:15 aspect ratio
 					var diva_width = 500_000.0

--- a/autoloads/song_loader/song_loaders/dsc_opcode_db.json
+++ b/autoloads/song_loader/song_loaders/dsc_opcode_db.json
@@ -87,6 +87,10 @@
         "info_X": {
             "id": 85,
             "len": 1
+        },
+        "info_f": {
+            "id": 85,
+            "len": 1
         }
     },
     "BAR_TIME_SET": {
@@ -121,6 +125,10 @@
     },
     "BEAT_POINT": {
         "info_X": {
+            "id": 86,
+            "len": 1
+        },
+        "info_f": {
             "id": 86,
             "len": 1
         }

--- a/tools/editor/editor_modules/ImportsModule.gd
+++ b/tools/editor/editor_modules/ImportsModule.gd
@@ -81,7 +81,7 @@ class DSCImporter:
 		
 		options_button = OptionButton.new()
 		options_button.add_item("Future Tone/M39s")
-		options_button.add_item("F/DT2")
+		options_button.add_item("F/DT/X")
 		options_button.add_item("F2nd")
 		
 		add_child(options_button)
@@ -92,7 +92,7 @@ class DSCImporter:
 			DSC_OPTIONS.FT:
 				game = "FT/MM/MM+"
 			DSC_OPTIONS.F:
-				game = "F/DT2"
+				game = "F/DT/X"
 			DSC_OPTIONS.F2:
 				game = "F2nd"
 		


### PR DESCRIPTION
As the title says, extracted `.dsc` chart files from _Project Diva X_ can now be imported, including Heartbeat's new Rush notes.

I put the functionality into the existing F/DT import preset, since X's charts are close enough to not interfere with importing those charts at all.

I also changed the F/DT2 import option to say DT instead of DT2, since I've tested and can confirm that all three _Dreamy Theater_ games' charts work with that import option.