### PR TITLE
Bug fixes and QoL changes to console-to-arcade modifier

### DIFF
--- a/rythm_game/game_modes/RhythmGameBase.gd
+++ b/rythm_game/game_modes/RhythmGameBase.gd
@@ -153,6 +153,7 @@ func set_chart(chart: HBChart):
 	# Find slide hold chains
 	result.max_score = chart._max_score_from_timing_points(tp)
 	game_ui._on_chart_set(chart)
+	game_ui.set_clear_bar_max(result)
 
 # Override this
 func get_chart_from_song(song: HBSong, difficulty) -> HBChart:

--- a/rythm_game/game_modes/RhythmGameBase.gd
+++ b/rythm_game/game_modes/RhythmGameBase.gd
@@ -151,7 +151,7 @@ func set_chart(chart: HBChart):
 		modifier._preprocess_timing_points(tp)
 	_set_timing_points(tp)
 	# Find slide hold chains
-	result.max_score = chart.get_max_score()
+	result.max_score = chart._max_score_from_timing_points(tp)
 	game_ui._on_chart_set(chart)
 
 # Override this

--- a/rythm_game/game_modes/heartbeat/HeartbeatRhythmGameUI.gd
+++ b/rythm_game/game_modes/heartbeat/HeartbeatRhythmGameUI.gd
@@ -142,9 +142,9 @@ func _on_reset():
 func reset_score_counter():
 	get_tree().set_group(SCORE_COUNTER_GROUP, "score", 0.0)
 	get_tree().call_group(SCORE_COUNTER_GROUP, "reset")
-	
-func _on_chart_set(chart: HBChart):
-	get_tree().set_group(CLEAR_BAR_GROUP, "max_value", chart.get_max_score())
+
+func set_clear_bar_max(result: HBResult):
+	get_tree().set_group(CLEAR_BAR_GROUP, "max_value", result.max_score)
 	_update_clear_bar_value()
 
 func try_show_intro_skip(song: HBSong):

--- a/rythm_game/game_modes/heartbeat/RhythmGameHeartbeat.gd
+++ b/rythm_game/game_modes/heartbeat/RhythmGameHeartbeat.gd
@@ -149,8 +149,8 @@ func _game_ready():
 func set_chart(chart: HBChart):
 	slide_hold_chains = chart.get_slide_hold_chains()
 	_potential_result = HBResult.new()
-	_potential_result.max_score = chart.get_max_score()
-	super.set_chart(chart)
+	super.set_chart(chart)	
+	_potential_result.max_score = result.max_score
 	if csv_timing_dump_enabled:
 		csv_timing_dump.reset()
 

--- a/rythm_game/modifiers/console_to_arcade/console_to_arcade.gd
+++ b/rythm_game/modifiers/console_to_arcade/console_to_arcade.gd
@@ -28,7 +28,7 @@ func _preprocess_timing_points(points: Array) -> Array:
 		if point is HBDoubleNote:
 			# Doubles to singles
 			points[i] = point.convert_to_type("Note")
-		elif point is HBSustainNote:
+		elif point is HBSustainNote and modifier_settings.sustain_mode != HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.NO_CHANGE:
 			# Sustains to two notes
 			var pt := point.convert_to_type("Note") as HBNoteData
 			points[i] = pt
@@ -66,12 +66,14 @@ static func get_option_settings() -> Dictionary:
 			"options_pretty": [
 				TranslationServer.tr("Replace with two notes", &"Console to arcade modifier sustain_mode two note option"),
 				TranslationServer.tr("Replace with hold", &"Console to arcade modifier sustain_mode hold option"),
-				TranslationServer.tr("Replace with one note", &"Console to arcade modifier sustain_mode single note option")
+				TranslationServer.tr("Replace with one note", &"Console to arcade modifier sustain_mode single note option"),
+				TranslationServer.tr("Don't change", &"Console to arcade modifier sustain_mode no change option")
 			],
 			"options": [
 				HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.TWO_NOTES,
 				HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.HOLD,
 				HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.SINGLE_NOTE,
+				HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.NO_CHANGE
 			],
 			"type": "options"
 		}

--- a/rythm_game/modifiers/console_to_arcade/console_to_arcade.gd
+++ b/rythm_game/modifiers/console_to_arcade/console_to_arcade.gd
@@ -29,7 +29,7 @@ func _preprocess_timing_points(points: Array) -> Array:
 			# Doubles to singles
 			points[i] = point.convert_to_type("Note")
 		elif point is HBSustainNote and modifier_settings.sustain_mode != HBConsoleToArcadeModifierSettings.SUSTAIN_MODE.NO_CHANGE:
-			# Sustains to two notes
+			# Sustains to singles
 			var pt := point.convert_to_type("Note") as HBNoteData
 			points[i] = pt
 			match modifier_settings.sustain_mode:

--- a/rythm_game/modifiers/console_to_arcade/console_to_arcade_settings.gd
+++ b/rythm_game/modifiers/console_to_arcade/console_to_arcade_settings.gd
@@ -7,7 +7,8 @@ var keep_hearts := false
 enum SUSTAIN_MODE {
 	TWO_NOTES,
 	HOLD,
-	SINGLE_NOTE
+	SINGLE_NOTE,
+	NO_CHANGE,
 }
 
 var sustain_mode: SUSTAIN_MODE = SUSTAIN_MODE.TWO_NOTES

--- a/scripts/HBChart.gd
+++ b/scripts/HBChart.gd
@@ -220,9 +220,13 @@ func backport_chart(song):
 	
 	self.format_version -= 1
 
-# Returns the max score, not including the extra hold score.
 func get_max_score():
 	var tp = get_timing_points()
+	return _max_score_from_timing_points(tp)
+
+# Returns the max score, not including the extra hold score.
+func _max_score_from_timing_points(timing_points):
+	var tp = timing_points
 	var max_score = 0.0
 	
 	var last_point: HBBaseNote


### PR DESCRIPTION
Fixes #428.

* Added an option to not modify sustain notes when using the console-to-arcade modifier
* Fixed the post-score clear percentage calculations when using the console-to-arcade modifier; additionally fixed the in-song display of such.

